### PR TITLE
Add composer to PATH (fix drush: command not found)

### DIFF
--- a/.environment
+++ b/.environment
@@ -1,5 +1,11 @@
 export RELATIONSHIPS_JSON="$(echo $PLATFORM_RELATIONSHIPS | base64 --decode)"
 
+# Allow executable app dependencies from Composer to be run from the path.
+if [ -n "$PLATFORM_APP_DIR" -a -f "$PLATFORM_APP_DIR"/composer.json ] ; then
+  bin=$(composer config bin-dir --working-dir="$PLATFORM_APP_DIR" --no-interaction 2>/dev/null)
+  export PATH="${PLATFORM_APP_DIR}/${bin:-vendor/bin}:${PATH}"
+fi
+
 # Set database environment variables
 export DB_HOST="$(echo $RELATIONSHIPS_JSON | jq -r '.mariadb[0].host')"
 export DB_PORT="$(echo $RELATIONSHIPS_JSON | jq -r '.mariadb[0].port')"


### PR DESCRIPTION
## Description
Adding composer to PATH so drush can be ran on platformsh environment.

## Motivation and Context
Created a platform.sh project with the template. `drush` command was not available in builds. Error like this appears on the build log
```
  Executing deploy hook for application drupal
    Created Drush configuration file: /app/.drush/drush.yml
    W: /app/drush/platformsh_deploy_drupal.sh: line 9: drush: command not found
    Drupal not installed. Skipping standard Drupal deploy steps
```

## How Has This Been Tested?
After adding this change I was able to `drush` on platform.sh and the builds work.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [x] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
