### PR TITLE
fix: update mariadb to 10.11, composer use 2.7.0, fixes #6

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -154,7 +154,7 @@ web:
 # More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
 dependencies:
     php:
-        composer/composer: "^2.7"
+        composer/composer: "^2.7.0"
 
 # Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
 # More information: https://docs.platform.sh/create-apps/app-reference.html#hooks

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -4,7 +4,7 @@
 # to power your Platform.sh project.
 
 db:
-    type: mariadb:10.6
+    type: mariadb:10.11
     disk: 2048
 
 cache:


### PR DESCRIPTION
## Description
Please describe your changes in detail according to the information below

## Related Issue

* #6 
* https://github.com/ddev/ddev-platformsh/pull/138
* https://github.com/platformsh-templates/drupal10/pull/225

- [x] The mariadb version makes sense to be current stable 10.11, which is what the drupal10 template uses (instead of 10.6 used here)
- [x] Use composer 2.7.0 instead of 2.7 just to pacify DDEV usage, which does a composer self-update (which can't take a branch most of the time), this is identical to the approach for drupal10 in https://github.com/platformsh-templates/drupal10/pull/225 (but 2.3.6 would probably work here as well)

## Motivation and Context

Use current mariadb. Use a composer spec that works for ddev/ddev-platformsh.

## How Has This Been Tested?

Minor change

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [ ] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
