### PR TITLE
[Fixes #13] Add webm and webp to allowed static file types

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -98,7 +98,7 @@ web:
             # Rules for specific URI patterns.
             rules:
                 # Allow access to common static files.
-                '\.(avif|webp|jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                '\.(avif|webp|jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|web[mp]|woff2?|otf|ttf)$':
                     allow: true
                 '^/robots\.txt$':
                     allow: true


### PR DESCRIPTION
## Description

The allowed static file types is extended to include webp and webm files.

## Related Issue

https://github.com/platformsh-templates/drupal11/issues/13

## Motivation and Context

WebP is a popular enough format to be enabled by default.

## How Has This Been Tested?

I added this to my app template and it fixed the problem.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [x] I have read the contribution guide
- [x] I have created an issue following the issue guide
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
