### PR TITLE
Add vendor/bin into $PATH so `drush` can be used

### DIFF
--- a/.environment
+++ b/.environment
@@ -1,3 +1,9 @@
+# Allow executable app dependencies from Composer to be run from the path.
+if [ -n "$PLATFORM_APP_DIR" -a -f "$PLATFORM_APP_DIR"/composer.json ] ; then
+  bin=$(composer config bin-dir --working-dir="$PLATFORM_APP_DIR" --no-interaction 2>/dev/null)
+  export PATH="${PLATFORM_APP_DIR}/${bin:-vendor/bin}:${PATH}"
+fi
+
 export RELATIONSHIPS_JSON="$(echo $PLATFORM_RELATIONSHIPS | base64 --decode)"
 
 # Set database environment variables


### PR DESCRIPTION
Replace PATH setting. It was mistakenly deleted recently. (regression)

## Description

Report:

> upon deployment for this project , which came from the upsun template i get
>"Drupal not installed. Skipping standard Drupal deploy steps"
> so i cant access drush

Analysis:

> drush exists, is can be found in vendor/bin/drush
> What seems to be missing is the expected line in .environment that adds vendor/bin to your $PATH so that utilities there can be found. 
> 
> I see that [the Drupal 11 template](https://github.com/platformsh-templates/drupal11/blob/master/.environment) has removed it. that's a mistake.
> [The Drupal 10 version](https://github.com/platformsh-templates/drupal10/blob/master/.environment) has it correct.

Solution:

Restore functionality that was present in all previous templates.

## Related Issue

When installing Drupal 11 out of the box with this template, the drush commands fail.

```
Creating environment main
    Starting environment
    Updating endpoints for drupal and router
    Opening application drupal and its relationships
    Executing deploy hook for application drupal
      Created Drush configuration file: /app/.drush/drush.yml
      W: /app/drush/platformsh_deploy_drupal.sh: line 9: drush: command not found
      Drupal not installed. Skipping standard Drupal deploy steps
```

### Please drop a link to the issue here:

Customer reported issue. Verified and replicated by support staff. Regression verified by git history inspection.

https://platformsh.zendesk.com/agent/tickets/444596
https://platformsh.slack.com/archives/C06KG3APLPJ/p1765368112080699?thread_ts=1765368043.041159&cid=C06KG3APLPJ

## Motivation and Context

A recent commit inadvertantly removed pre-existing functionalit. This change restores the behaviour.

## How Has This Been Tested?

All previous Drupal versions that used earlier versions of this template worked due to the PATH setting. The current iteration does not, as the setting was removed. The previous behaviour works and has been tested.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [x] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
